### PR TITLE
fix: link against QTNetwork for QLocalSocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Started as [MangoHud](https://github.com/flightlessmango/MangoHud) fork.
 * glslangValidator
 * python3
 * Xlib
-* Qt5 - QtWebEngineWidgets
+* Qt5 - Core, Network, Widgets WebEngineWidgets
 
 #### Build
 ```sh

--- a/client/meson.build
+++ b/client/meson.build
@@ -1,7 +1,7 @@
 bindir_client = join_paths(get_option('prefix'), get_option('bindir'))
 
 qt5 = import('qt5')
-qt5_dep = dependency('qt5', modules: ['Core', 'Widgets', 'WebEngineWidgets'])
+qt5_dep = dependency('qt5', modules: ['Core', 'Network', 'Widgets', 'WebEngineWidgets'])
 
 client_files = files(
   'main.cpp',


### PR DESCRIPTION
```
../client/manager.cpp:9:10: fatal error: QLocalSocket: No such file or directory
```
`QLocalSocket` is in `QtNetwork`, so linked against that. Also specified the rest of qt5 includes in readme (they're separate packages in some distro).
